### PR TITLE
显式增加 lib

### DIFF
--- a/makefile
+++ b/makefile
@@ -48,7 +48,7 @@ linux_nolibnet:git_version
 
 freebsd:git_version
 	rm -f ${OUTPUTS}
-	${cc_local}   -o ${NAME}          -I. ${SOURCES} ${PCAP} ${LIBNET} ${FLAGS} -lrt -ggdb -static -O2
+	${cc_local}   -o ${NAME}         -I. ${SOURCES} -lpcap -lnet -lrdmacm -libverbs -lvgl -lvmmapi ${LIBNET} $(FLAGS) -lrt -ggdb -static -O2 -L/usr/lib
 
 freebsd_nolibnet:git_version
 	rm -f ${OUTPUTS}


### PR DESCRIPTION
针对 FreeBSD，需要增加  `-lnet `以便系统自动搜索 `libnet.h` ，增加 `-lpcap` 以便解决make 时 `pcap` 错误，`-lrdmacm -libverbs -lvgl -lvmmapi` 则解决相应的 rdmsniff 等等错误。

这些参数都是系统会自动去查找的，但是需要 makefile 中指出。

从 https://github.com/wangyu-/udp2raw-multiplatform/issues/24#issuecomment-501305568 修改而来